### PR TITLE
feat: add live indexing progress with auto-refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,24 @@
 import { useCallback, useState } from "react"
 import { Env } from "@dcl/ui-env"
+import PauseIcon from "@mui/icons-material/Pause"
+import PlayArrowIcon from "@mui/icons-material/PlayArrow"
 import { ThemeProvider, dark } from "decentraland-ui2/dist/theme"
 import {
   Alert,
   Box,
+  Chip,
   CircularProgress,
+  IconButton,
   Snackbar,
   Toolbar,
+  Tooltip,
   Typography,
 } from "@mui/material"
 import Sidebar from "./components/Sidebar"
 import SquidsTable from "./components/SquidsTable"
 import TopBar from "./components/TopBar"
 import { config } from "./config"
-import { useSquids } from "./hooks/useSquids"
+import { POLL_INTERVAL_MS, useSquids } from "./hooks/useSquids"
 
 const drawerWidth = 240
 
@@ -40,8 +45,16 @@ const App = () => {
     setSnackbar((prev) => ({ ...prev, open: false }))
   }
 
-  const { squids, loading, error, promoteSquid, stopSquid } =
-    useSquids(showMessage)
+  const {
+    squids,
+    loading,
+    error,
+    lastUpdated,
+    isPolling,
+    setIsPolling,
+    promoteSquid,
+    stopSquid,
+  } = useSquids(showMessage)
   const [mobileOpen, setMobileOpen] = useState(false)
 
   const handleDrawerToggle = () => {
@@ -69,9 +82,49 @@ const App = () => {
           }}
         >
           <Toolbar />
-          <Typography variant="h5" gutterBottom sx={{ paddingBottom: 2 }}>
-            {isDev ? "Dev" : "Prod"} Squids
-          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+              gap: 1,
+              paddingBottom: 2,
+            }}
+          >
+            <Typography variant="h5">
+              {isDev ? "Dev" : "Prod"} Squids
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              {lastUpdated && (
+                <Typography variant="caption" color="text.secondary">
+                  Updated {lastUpdated.toLocaleTimeString()}
+                </Typography>
+              )}
+              <Chip
+                size="small"
+                color={isPolling ? "success" : "default"}
+                label={
+                  isPolling
+                    ? `Live · every ${POLL_INTERVAL_MS / 1000}s`
+                    : "Paused"
+                }
+              />
+              <Tooltip
+                title={isPolling ? "Pause auto-refresh" : "Resume auto-refresh"}
+              >
+                <IconButton
+                  size="small"
+                  onClick={() => setIsPolling((prev) => !prev)}
+                  aria-label={
+                    isPolling ? "pause auto-refresh" : "resume auto-refresh"
+                  }
+                >
+                  {isPolling ? <PauseIcon /> : <PlayArrowIcon />}
+                </IconButton>
+              </Tooltip>
+            </Box>
+          </Box>
           {loading && (
             <Box
               sx={{

--- a/src/components/SquidsTable.tsx
+++ b/src/components/SquidsTable.tsx
@@ -11,6 +11,7 @@ import {
   Chip,
   Collapse,
   IconButton,
+  LinearProgress,
   Menu,
   MenuItem,
   Paper,
@@ -28,6 +29,7 @@ import { Squid, SquidMetrics } from "../types"
 import {
   getGraphQLEndpoint,
   getSquidOperationalStatus,
+  getSyncProgress,
   hasLiveService,
   parseProjectName,
 } from "../utils"
@@ -88,6 +90,37 @@ const renameNetwork = (network: Network): string => {
 const renderStatusBadge = (status: string, color: string): JSX.Element => (
   <Chip label={status} size="small" sx={{ bgcolor: color, color: "#fff" }} />
 )
+
+const renderProgressBar = (metrics: SquidMetrics): JSX.Element => {
+  const progress = getSyncProgress(metrics)
+  const isSynced = progress >= 100
+
+  return (
+    <Box sx={{ minWidth: 150 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 0.5,
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          {metrics.sqd_processor_last_block} /{" "}
+          {metrics.sqd_processor_chain_height}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {progress.toFixed(2)}%
+        </Typography>
+      </Box>
+      <LinearProgress
+        variant="determinate"
+        value={progress}
+        color={isSynced ? "success" : "warning"}
+        sx={{ height: 6, borderRadius: 3 }}
+      />
+    </Box>
+  )
+}
 
 const getRelativeTime = (date: string): string => {
   const now = new Date()
@@ -166,6 +199,7 @@ const SquidsTable: React.FC<SquidsTableProps> = ({
           {chainMetrics.sqd_processor_last_block} /{" "}
           {chainMetrics.sqd_processor_chain_height}
         </TableCell>
+        <TableCell>{renderProgressBar(chainMetrics)}</TableCell>
         <TableCell>
           {renderStatusBadge(
             chainMetrics.sqd_processor_sync_eta_seconds === 0
@@ -296,21 +330,30 @@ const SquidsTable: React.FC<SquidsTableProps> = ({
                         <TableCell>
                           {Object.entries(squid.metrics).map(
                             ([chain, chainMetrics]) => (
-                              <div key={chain} style={{ marginBottom: "4px" }}>
-                                <strong style={{ paddingRight: 8 }}>
-                                  {renameNetwork(chain as Network)}:
-                                </strong>
-                                {renderStatusBadge(
-                                  chainMetrics.sqd_processor_sync_eta_seconds ===
-                                    0
-                                    ? "Synced"
-                                    : "Indexing",
-                                  chainMetrics.sqd_processor_sync_eta_seconds ===
-                                    0
-                                    ? "green"
-                                    : "orange"
-                                )}
-                              </div>
+                              <Box key={chain} sx={{ marginBottom: 1.5 }}>
+                                <Box
+                                  sx={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    marginBottom: 0.5,
+                                  }}
+                                >
+                                  <strong style={{ paddingRight: 8 }}>
+                                    {renameNetwork(chain as Network)}:
+                                  </strong>
+                                  {renderStatusBadge(
+                                    chainMetrics.sqd_processor_sync_eta_seconds ===
+                                      0
+                                      ? "Synced"
+                                      : "Indexing",
+                                    chainMetrics.sqd_processor_sync_eta_seconds ===
+                                      0
+                                      ? "green"
+                                      : "orange"
+                                  )}
+                                </Box>
+                                {renderProgressBar(chainMetrics)}
+                              </Box>
                             )
                           )}
                         </TableCell>
@@ -463,6 +506,7 @@ const SquidsTable: React.FC<SquidsTableProps> = ({
                                         <TableCell>
                                           Last Block Processed
                                         </TableCell>
+                                        <TableCell>Progress</TableCell>
                                         <TableCell>Status</TableCell>
                                       </TableRow>
                                     </TableHead>

--- a/src/hooks/useSquids.ts
+++ b/src/hooks/useSquids.ts
@@ -1,6 +1,9 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { config } from "../config"
 import { Squid } from "../types"
+
+// How often the squid list is refreshed to show live indexing progress.
+export const POLL_INTERVAL_MS = 3000
 
 export const useSquids = (
   showMessage: (message: string, type: "success" | "error") => void
@@ -8,30 +11,68 @@ export const useSquids = (
   const [squids, setSquids] = useState<Squid[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [isPolling, setIsPolling] = useState(true)
+  // Guards against overlapping requests when a refresh is slower than the interval.
+  const isFetchingRef = useRef(false)
 
-  const fetchSquids = async () => {
-    try {
-      const response = await fetch(
-        `${config.get("SQUID_MANAGEMENT_SERVER")}/list`,
-        {
-          credentials: "include",
+  const fetchSquids = useCallback(
+    async (isBackground = false) => {
+      // Only background polls yield to an in-flight request. The foreground load
+      // must always run so the initial spinner is cleared even if a poll is active.
+      if (isBackground && isFetchingRef.current) {
+        return
+      }
+      isFetchingRef.current = true
+      try {
+        const response = await fetch(
+          `${config.get("SQUID_MANAGEMENT_SERVER")}/list`,
+          {
+            credentials: "include",
+          }
+        )
+        if (!response.ok) {
+          throw new Error("Failed to fetch squids")
         }
-      )
-      const data: Squid[] = await response.json()
-      setSquids(
-        data.sort((a, b) => a.service_name.localeCompare(b.service_name))
-      )
-    } catch (err) {
-      setError("Failed to fetch squids")
-      showMessage("Failed to fetch squids", "error")
-    } finally {
-      setLoading(false)
-    }
-  }
+        const data: Squid[] = await response.json()
+        setSquids(
+          data.sort((a, b) => a.service_name.localeCompare(b.service_name))
+        )
+        setError(null)
+        setLastUpdated(new Date())
+      } catch (err) {
+        // Background polls keep the last good data and stay quiet to avoid
+        // replacing the table and spamming the snackbar on transient errors.
+        if (!isBackground) {
+          setError("Failed to fetch squids")
+          showMessage("Failed to fetch squids", "error")
+        }
+      } finally {
+        // Only the foreground load drives the spinner; polls leave it untouched.
+        if (!isBackground) {
+          setLoading(false)
+        }
+        isFetchingRef.current = false
+      }
+    },
+    [showMessage]
+  )
 
+  // Initial load.
   useEffect(() => {
     fetchSquids()
-  }, [showMessage])
+  }, [fetchSquids])
+
+  // Auto-refresh to surface live indexing progress.
+  useEffect(() => {
+    if (!isPolling) {
+      return
+    }
+    const intervalId = setInterval(() => {
+      fetchSquids(true)
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(intervalId)
+  }, [isPolling, fetchSquids])
 
   const promoteSquid = async (id: string): Promise<void> => {
     try {
@@ -67,5 +108,15 @@ export const useSquids = (
     }
   }
 
-  return { squids, loading, error, promoteSquid, stopSquid, fetchSquids }
+  return {
+    squids,
+    loading,
+    error,
+    lastUpdated,
+    isPolling,
+    setIsPolling,
+    promoteSquid,
+    stopSquid,
+    fetchSquids,
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ export interface SquidMetrics {
   sqd_processor_mapping_blocks_per_second: number
   sqd_processor_last_block: number
   sqd_processor_chain_height: number
+  // Derived percentage of the chain indexed (0–100). Optional so the UI keeps
+  // working against server versions that do not send it yet (computed as a fallback).
+  progress?: number
 }
 
 export interface Squid {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,32 @@
 import { Network } from "@dcl/schemas"
 import { Env } from "@dcl/ui-env"
 import { config } from "./config"
-import { Squid } from "./types"
+import { Squid, SquidMetrics } from "./types"
+
+/**
+ * Returns the indexing progress for a chain as a percentage in the [0, 100] range.
+ * Uses the value provided by the server when present and falls back to computing it
+ * from the last processed block and the chain height (e.g. against older servers).
+ * @param metrics The metrics for a given chain
+ * @returns The progress percentage rounded to 2 decimals
+ */
+export const getSyncProgress = (metrics: SquidMetrics): number => {
+  const {
+    sqd_processor_last_block: lastBlock,
+    sqd_processor_chain_height: chainHeight,
+  } = metrics
+
+  const raw =
+    typeof metrics.progress === "number" && Number.isFinite(metrics.progress)
+      ? metrics.progress
+      : chainHeight > 0
+        ? (lastBlock / chainHeight) * 100
+        : 0
+
+  // Clamp and round both the server-provided and the computed value, so the
+  // progress bar and percentage never go out of the [0, 100] range.
+  return Math.min(100, Math.max(0, Math.round(raw * 100) / 100))
+}
 
 /**
  * Generates the GraphQL endpoint URL based on the service name.


### PR DESCRIPTION
## Context

Operators want to watch indexing progress live without manually reloading. This adds auto-refresh and an indexing progress bar (current block vs chain height) per indexer.

Pairs with squid-management-server#81, which adds the `progress` field to `GET /list` and caches the squid topology so the endpoint is cheap to poll every few seconds.

## Changes

- **Auto-refresh**: `useSquids` polls `GET /list` every 3s. The initial load shows the spinner; background polls update silently — they keep the last good data and do not spam the error snackbar on transient failures. An in-flight guard prevents overlapping background requests (the foreground load always runs so the spinner is never stranded).
- **Live indicator**: a `Live · every 3s` / `Paused` chip with a pause/resume toggle and the last-updated time in the header.
- **Progress bars**: a `LinearProgress` per chain showing `% indexed` and `last_block / chain_height`, both in the collapsed status column and the expanded chain-data table.
- **Progress source**: `getSyncProgress` uses the server-provided `progress` when available and falls back to computing it from `last_block / chain_height`. Both paths are clamped/sanitized to `[0, 100]`.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual: confirm the table refreshes ~every 3s, progress bars advance, and the pause/resume toggle stops/resumes polling