### PR TITLE
fix: replace auto-poll with manual refresh and format eta

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useState } from "react"
 import { Env } from "@dcl/ui-env"
-import PauseIcon from "@mui/icons-material/Pause"
-import PlayArrowIcon from "@mui/icons-material/PlayArrow"
+import RefreshIcon from "@mui/icons-material/Refresh"
 import { ThemeProvider, dark } from "decentraland-ui2/dist/theme"
 import {
   Alert,
   Box,
-  Chip,
   CircularProgress,
   IconButton,
   Snackbar,
@@ -18,7 +16,7 @@ import Sidebar from "./components/Sidebar"
 import SquidsTable from "./components/SquidsTable"
 import TopBar from "./components/TopBar"
 import { config } from "./config"
-import { POLL_INTERVAL_MS, useSquids } from "./hooks/useSquids"
+import { useSquids } from "./hooks/useSquids"
 
 const drawerWidth = 240
 
@@ -48,12 +46,12 @@ const App = () => {
   const {
     squids,
     loading,
+    refreshing,
     error,
     lastUpdated,
-    isPolling,
-    setIsPolling,
     promoteSquid,
     stopSquid,
+    fetchSquids,
   } = useSquids(showMessage)
   const [mobileOpen, setMobileOpen] = useState(false)
 
@@ -101,27 +99,21 @@ const App = () => {
                   Updated {lastUpdated.toLocaleTimeString()}
                 </Typography>
               )}
-              <Chip
-                size="small"
-                color={isPolling ? "success" : "default"}
-                label={
-                  isPolling
-                    ? `Live · every ${POLL_INTERVAL_MS / 1000}s`
-                    : "Paused"
-                }
-              />
-              <Tooltip
-                title={isPolling ? "Pause auto-refresh" : "Resume auto-refresh"}
-              >
-                <IconButton
-                  size="small"
-                  onClick={() => setIsPolling((prev) => !prev)}
-                  aria-label={
-                    isPolling ? "pause auto-refresh" : "resume auto-refresh"
-                  }
-                >
-                  {isPolling ? <PauseIcon /> : <PlayArrowIcon />}
-                </IconButton>
+              <Tooltip title={refreshing ? "Refreshing…" : "Refresh"}>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() => fetchSquids()}
+                    disabled={refreshing}
+                    aria-label="refresh"
+                  >
+                    {refreshing ? (
+                      <CircularProgress size={18} />
+                    ) : (
+                      <RefreshIcon />
+                    )}
+                  </IconButton>
+                </span>
               </Tooltip>
             </Box>
           </Box>

--- a/src/components/SquidsTable.tsx
+++ b/src/components/SquidsTable.tsx
@@ -27,6 +27,7 @@ import {
 import { config } from "../config"
 import { Squid, SquidMetrics } from "../types"
 import {
+  formatEta,
   getGraphQLEndpoint,
   getSquidOperationalStatus,
   getSyncProgress,
@@ -190,7 +191,9 @@ const SquidsTable: React.FC<SquidsTableProps> = ({
     return (
       <TableRow>
         <TableCell>{renameNetwork(chain)}</TableCell>
-        <TableCell>{chainMetrics.sqd_processor_sync_eta_seconds}s</TableCell>
+        <TableCell>
+          {formatEta(chainMetrics.sqd_processor_sync_eta_seconds)}
+        </TableCell>
         <TableCell>
           {chainMetrics.sqd_processor_mapping_blocks_per_second.toFixed(2)}{" "}
           blocks/s
@@ -499,9 +502,7 @@ const SquidsTable: React.FC<SquidsTableProps> = ({
                                     <TableHead>
                                       <TableRow>
                                         <TableCell>Chain</TableCell>
-                                        <TableCell>
-                                          Sync ETA (Seconds)
-                                        </TableCell>
+                                        <TableCell>Sync ETA</TableCell>
                                         <TableCell>Speed</TableCell>
                                         <TableCell>
                                           Last Block Processed

--- a/src/hooks/useSquids.ts
+++ b/src/hooks/useSquids.ts
@@ -2,77 +2,61 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { config } from "../config"
 import { Squid } from "../types"
 
-// How often the squid list is refreshed to show live indexing progress.
-export const POLL_INTERVAL_MS = 3000
-
 export const useSquids = (
   showMessage: (message: string, type: "success" | "error") => void
 ) => {
   const [squids, setSquids] = useState<Squid[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
-  const [isPolling, setIsPolling] = useState(true)
-  // Guards against overlapping requests when a refresh is slower than the interval.
+  // Guards against overlapping requests (e.g. double-clicking refresh while a
+  // slow /list is still in flight).
   const isFetchingRef = useRef(false)
+  // Tracks whether we ever loaded data, so a failed refresh keeps showing it.
+  const hasLoadedRef = useRef(false)
 
-  const fetchSquids = useCallback(
-    async (isBackground = false) => {
-      // Only background polls yield to an in-flight request. The foreground load
-      // must always run so the initial spinner is cleared even if a poll is active.
-      if (isBackground && isFetchingRef.current) {
-        return
+  const fetchSquids = useCallback(async () => {
+    if (isFetchingRef.current) {
+      return
+    }
+    isFetchingRef.current = true
+    setRefreshing(true)
+    try {
+      const response = await fetch(
+        `${config.get("SQUID_MANAGEMENT_SERVER")}/list`,
+        {
+          credentials: "include",
+        }
+      )
+      if (!response.ok) {
+        throw new Error("Failed to fetch squids")
       }
-      isFetchingRef.current = true
-      try {
-        const response = await fetch(
-          `${config.get("SQUID_MANAGEMENT_SERVER")}/list`,
-          {
-            credentials: "include",
-          }
-        )
-        if (!response.ok) {
-          throw new Error("Failed to fetch squids")
-        }
-        const data: Squid[] = await response.json()
-        setSquids(
-          data.sort((a, b) => a.service_name.localeCompare(b.service_name))
-        )
-        setError(null)
-        setLastUpdated(new Date())
-      } catch (err) {
-        // Background polls keep the last good data and stay quiet to avoid
-        // replacing the table and spamming the snackbar on transient errors.
-        if (!isBackground) {
-          setError("Failed to fetch squids")
-          showMessage("Failed to fetch squids", "error")
-        }
-      } finally {
-        // Only the foreground load drives the spinner; polls leave it untouched.
-        if (!isBackground) {
-          setLoading(false)
-        }
-        isFetchingRef.current = false
+      const data: Squid[] = await response.json()
+      setSquids(
+        data.sort((a, b) => a.service_name.localeCompare(b.service_name))
+      )
+      setError(null)
+      setLastUpdated(new Date())
+      hasLoadedRef.current = true
+    } catch (err) {
+      showMessage("Failed to fetch squids", "error")
+      // Only block the view with an error when there is nothing to show yet;
+      // a failed manual refresh keeps the last good data on screen.
+      if (!hasLoadedRef.current) {
+        setError("Failed to fetch squids")
       }
-    },
-    [showMessage]
-  )
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+      isFetchingRef.current = false
+    }
+  }, [showMessage])
 
-  // Initial load.
+  // Initial load. Afterwards the list is only refreshed on demand.
   useEffect(() => {
     fetchSquids()
   }, [fetchSquids])
-
-  // Auto-refresh to surface live indexing progress.
-  useEffect(() => {
-    if (!isPolling) {
-      return
-    }
-    const intervalId = setInterval(() => {
-      fetchSquids(true)
-    }, POLL_INTERVAL_MS)
-    return () => clearInterval(intervalId)
-  }, [isPolling, fetchSquids])
 
   const promoteSquid = async (id: string): Promise<void> => {
     try {
@@ -111,10 +95,9 @@ export const useSquids = (
   return {
     squids,
     loading,
+    refreshing,
     error,
     lastUpdated,
-    isPolling,
-    setIsPolling,
     promoteSquid,
     stopSquid,
     fetchSquids,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,38 @@ export const getSyncProgress = (metrics: SquidMetrics): number => {
 }
 
 /**
+ * Formats a sync ETA given in seconds into a short, human-readable string.
+ * Shows the two most significant units (e.g. "1h 23m", "5m 12s", "45s") and
+ * returns "Synced" when there is no remaining time.
+ * @param seconds The estimated time to sync in seconds
+ * @returns A human-readable ETA
+ */
+export const formatEta = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "Synced"
+  }
+
+  const total = Math.round(seconds)
+  const units = [
+    { value: Math.floor(total / 86400), label: "d" },
+    { value: Math.floor((total % 86400) / 3600), label: "h" },
+    { value: Math.floor((total % 3600) / 60), label: "m" },
+    { value: total % 60, label: "s" },
+  ]
+
+  const firstIndex = units.findIndex((unit) => unit.value > 0)
+  if (firstIndex === -1) {
+    return "Synced"
+  }
+
+  return units
+    .slice(firstIndex, firstIndex + 2)
+    .filter((unit) => unit.value > 0)
+    .map((unit) => `${unit.value}${unit.label}`)
+    .join(" ")
+}
+
+/**
  * Generates the GraphQL endpoint URL based on the service name.
  * @param serviceName The name of the squid service
  * @returns The GraphQL endpoint URL


### PR DESCRIPTION
## Context

The live auto-refresh added in #27 polled `GET /list` every 3s. In practice `/list` is sometimes slow (~6s) and the polls started queueing up and spamming requests. This switches to on-demand refresh and makes the ETA readable.

## Changes

- **Removed the 3s auto-poll** (and the live/pause chip). The list now loads once and is only refreshed on demand, so slow `/list` responses can no longer queue up.
- **Manual refresh button**: a refresh icon next to the "Updated <time>" label. It shows a spinner and is disabled while a request is in flight (the in-flight guard also prevents double-clicks from overlapping).
- **Resilient refresh**: a failed manual refresh keeps the last good data on screen and just shows a snackbar; the blocking error view is only used when nothing has loaded yet.
- **Humanized ETA**: `formatEta` turns the raw seconds into `1h 23m` / `5m 12s` / `45s` / `Synced`. Column header renamed `Sync ETA (Seconds)` → `Sync ETA`.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test`
- [ ] Manual: list loads once (no background polling in the network tab), the refresh button updates the table and spins while loading, and ETAs render in the new format